### PR TITLE
Document the text WebSocket protocol and the Spectrum Data packet

### DIFF
--- a/PROTOCOL-SPECTRUM.md
+++ b/PROTOCOL-SPECTRUM.md
@@ -1,0 +1,76 @@
+# Spectrum Data (0x7F) binary packet
+
+The Spectrum Data packet carries one frame of spectrum bins to the browser.
+It shares the RTP-style `12 + cc*4` byte header used by Channel Data (0x7E),
+but the payload is not TLV-encoded: it is a fixed 92-byte record followed by
+exactly `binCount` bytes of bin data, one byte per bin.
+
+This document was derived from `html/radio.js`'s decode loop and checked
+against captured frames from three front ends (a direct-sampling HF receiver,
+a complex/IQ VHF tuner and a real-sampling UHF one).
+
+## Fixed record (92 bytes, immediately after the RTP header)
+
+**The first 16 bytes are big-endian; every field after them is
+little-endian.** This is not a stylistic guess — `radio.js` reads the first
+three fields with `getUint32(i)` and no second argument (defaulting to
+big-endian), then passes `true` for every subsequent field. The `ntohl()`
+calls around the first three are no-ops (`v >>> 0`).
+
+| Offset | Size | Endian | Field | Notes |
+|---|---|---|---|---|
+| 0 | 4 | BE | `binCount` | Number of bins that follow. 1620 for every entry in `zoom_table[]` in `ka9q-web.c`. |
+| 4 | 4 | BE | `centerHz` | Centre of the displayed span, in **absolute RF Hz**. See below. |
+| 8 | 4 | BE | `frequencyHz` | The channel's tuned frequency — the same value and semantics as `BFREQ` in `PROTOCOL-TEXT.md`, delivered over the binary packet as well. |
+| 12 | 4 | BE | `binWidthHz` | Hz per bin. `binWidthHz * binCount` is the displayed span width. |
+| 16 | 4 | LE | `input_samprate` | The front end's sample rate. |
+| 20 | 4 | LE | `rf_agc` | |
+| 24 | 8 | LE | `input_samples` | uint64 |
+| 32 | 8 | LE | `ad_over` | uint64 |
+| 40 | 8 | LE | `samples_since_over` | uint64 |
+| 48 | 8 | LE | `gps_time` | uint64 |
+| 56 | 4 | LE | `noise_bw` | float32 |
+| 60 | 4 | LE | `rf_atten` | float32 |
+| 64 | 4 | LE | `rf_gain` | float32 |
+| 68 | 4 | LE | `rf_level_cal` | float32 |
+| 72 | 4 | LE | `if_power` | float32, dB. Carries the same measurement as Channel Data's `IF_POWER` TLV — verified identical for the same moment on one connection. |
+| 76 | 4 | LE | `noise_density_audio` | float32 |
+| 80 | 4 | LE | `z_level` | uint32, current index into `zoom_table[]` |
+| 84 | 4 | LE | `bins_autorange_offset` | float32, dB. See bin decoding. |
+| 88 | 4 | LE | `bins_autorange_gain` | float32, dB per step. See bin decoding. |
+
+## Bin data
+
+Exactly `binCount` bytes follow the fixed record — a 1620-bin frame is
+`104 + 1620 = 1724` bytes in total, including the RTP header. Each byte is one
+bin, in ascending frequency order, and decodes as:
+
+```
+effective_gain = (bins_autorange_gain !== 0) ? bins_autorange_gain : 0.5
+dB             = bins_autorange_offset + effective_gain * byteValue
+```
+
+A `bins_autorange_gain` of `0` means no autorange data has arrived yet.
+`radio.js` substitutes `0.5`, matching radiod's own `init_chan` default.
+
+## `centerHz` is absolute, not baseband-relative
+
+`centerHz` is `sp->center_frequency` in `ka9q-web.c`, and it is in absolute RF
+Hz — the same convention as every other frequency field in this protocol. Use
+it exactly as received; no `FIRST_LO_FREQUENCY` correction is needed or
+wanted. `radio.js` does exactly this (`spectrum.setCenterHz(centerHz)`, with
+the value unmodified), and every server-side function that touches
+`sp->center_frequency` compares it directly against absolute,
+`Frontend.frequency`-derived bounds.
+
+This distinction is invisible on a direct-sampling HF receiver, where
+`Frontend.frequency` is ~0 Hz and "absolute" and "centred on a 0 Hz baseband
+window" are numerically identical. It matters on a tuner-based front end,
+where treating the field as baseband-relative — or adding the first LO
+frequency to it — puts the displayed centre out by the full LO frequency.
+
+If a genuinely baseband-relative value is ever needed, derive it explicitly as
+`centerHz - Frontend.frequency` rather than assuming the wire field is already
+relative. Note that `FIRST_LO_FREQUENCY` is decoded server-side but is not
+currently forwarded to the browser, so a client has no way to obtain
+`Frontend.frequency` on its own today.

--- a/PROTOCOL-TEXT.md
+++ b/PROTOCOL-TEXT.md
@@ -1,0 +1,93 @@
+# Text WebSocket protocol
+
+The binary RTP+TLV Channel Data (0x7E) and Spectrum Data (0x7F) stream carries
+front end telemetry — coverage, signal power, sample rates. It does not carry
+the tuned frequency or the mode. Those travel over a second, informal
+text protocol layered on the same WebSocket connection.
+
+This document was derived from `html/radio.js` and checked against live
+traffic from three running instances.
+
+## Inbound (server to client)
+
+Colon-delimited text frames:
+
+| Prefix | Example | Meaning |
+|---|---|---|
+| `S:<ssrc>` | `S:1234567890` | Assigns this connection's SSRC. |
+| `BFREQ:<val>` | `BFREQ:10000000.000` | Current backend (tuned) frequency. **The unit is ambiguous by magnitude**: `radio.js` treats a value above 1000000 as Hz, and anything else as kHz. Not reliably sent on connect — see below. |
+| `BFREQ_FORCE:<val>` | as `BFREQ` | Same meaning, but the client must apply it unconditionally. Used after reconnect or session recovery to override a locally adopted value. |
+| `SHIFT:<hz>` | `SHIFT:0.000` | BFO/shift frequency in Hz. Sent whenever the backend's shift differs from what this session was last told, so a freshly attached session always receives one. |
+| `M:<mode>` | `M:usb` | Demod mode/preset, lowercase. Not sent by the current server — see "Mode confirmation" below. `radio.js` still handles it. |
+| `M_FORCE:<mode>` | as `M` | The only mode notification the server actually sends, and only when adopting a backend-changed preset with no recent local command. |
+| `ACK:<clientId>:<seq>` | `ACK:ab12cd34:7` | Acknowledges a command carrying that `clientId`/`seq`. |
+| `BUSY:<reason>` | `BUSY:session limit reached` | Session rejected. `radio.js` shows a popup and stops reconnecting. |
+| `ZSIZE:<n>` | `ZSIZE:16` | Number of valid `zoom_table[]` indices, in reply to `Z:SIZE`. |
+| `PING` | `PING` | Keepalive, roughly every 2s from a dedicated thread. No reply expected. |
+
+## Outbound (client to server)
+
+Every command is wrapped as `C:<clientId>:<seq>:<rawCommand>` by
+`wrapControlMessage()` in `html/radio.js`. The server ACKs each one by echoing
+the `clientId` and `seq` back.
+
+| Raw command | Example | Meaning |
+|---|---|---|
+| `F:<khz>` | `F:14250.000` | Set frequency, in **kHz** to three decimals. Unlike the inbound `BFREQ` echo, this direction is unambiguous — it is always kHz. |
+| `M:<mode>` | `M:usb` | Set mode/preset, lowercase. |
+| `Z:<n>` | `Z:4` | Select a zoom level by **index into the server's `zoom_table[]`**. The client's own table must therefore stay in the same order as the server's; an entry present on one side only shifts every wider selection silently. |
+| `Z:+` / `Z:-` | `Z:+` | Step one zoom level in or out. |
+| `Z:c:<khz>` | `Z:c:145500.000` | Re-centre the spectrum view, in kHz. |
+| `Z:SIZE` | `Z:SIZE` | Query the zoom table size; answered with `ZSIZE:<n>`. |
+
+Commands for memories, spectrum display settings and the rest of the control
+surface exist but are not catalogued here.
+
+## Mode confirmation is asymmetric with frequency
+
+Sending `M:<mode>` produces only an `ACK`. No `M:` or `M_FORCE:` follows, even
+once the mode takes effect. This is the server's actual logic in
+`process_status_packet()`, not a timing artifact:
+
+- Handling your `M:<mode>` command makes `control_set_mode()` set
+  `sp->requested_preset` synchronously, so the session already knows what it
+  asked for.
+- On each subsequent status poll the server compares `Channel.preset` against
+  `sp->requested_preset`. **If they match, nothing is sent.** There is no
+  confirmation for a command that succeeded exactly as requested.
+- `M_FORCE:<preset>` is sent only when they do *not* match **and** no local
+  command was issued recently (a 5 second window) — that is, only to report
+  drift caused by something else, never to confirm your own request. If a
+  mismatch persists with a recent local command, the server re-sends the
+  requested preset internally after 5 failed polls, still without notifying
+  the browser.
+
+Frequency has no equivalent gap: `BFREQ`'s `backend_changed` check fires on any
+real change, whoever caused it. The practical consequence is that a
+mode-setting UI cannot wait for a state echo the way a frequency-tuning one
+can. Receipt of the `ACK` is the only signal that a mode command reached the
+server; whether it was applied has to be inferred some other way, and
+`Channel.preset` is not exposed to the browser today.
+
+## Sessions are reattached by client address, not created per connection
+
+`home()` looks up a session by `client_desc`, derived from the connection's
+source address by `client_desc_from_request()`, and reattaches the existing
+`struct session` if one is found, rather than allocating a fresh one per
+WebSocket connection.
+
+This has consequences a client has to account for:
+
+- **`BFREQ` may never arrive.** Its send is gated on
+  `last_sent_backend_frequency`, which is a single `static` in `ctrl_thread()`
+  shared by every session rather than per-session state. Whether a freshly
+  attached session receives a `BFREQ` therefore depends on what other sessions
+  have already caused to be recorded there, and tuning one session suppresses
+  or triggers notifications for others. Treat "no `BFREQ` yet" as "not yet
+  reported", not as a state in itself. `SHIFT` is the only message a freshly
+  attached session reliably receives.
+- **Clients sharing a source address share a session.** The code's own comment
+  anticipates "clients all sharing client_desc=127.0.0.1". The same applies to
+  any set of clients behind one NAT or reverse proxy that presents a single
+  source address: they can reattach to the same session and change each
+  other's tuning. Worth knowing when deploying behind a proxy.


### PR DESCRIPTION
Hi Wayne,

Two protocol documents. Independent of #8 and #9 — this one adds no code at
all, just documentation of what's already there.

While writing a client I had to reverse-engineer both of the protocols a
browser has to speak, since neither is written down: the colon-delimited text
frames that carry tuned frequency and mode, and the 0x7F Spectrum Data binary
packet. This is that work, tidied up. Everything was derived from
`html/radio.js` and checked against live traffic and captured frames from
three front ends — a direct-sampling HF receiver, a complex/IQ VHF tuner and a
real-sampling UHF one.

Beyond the wire formats, three behaviours seemed worth writing down because
they're easy to get wrong:

- **`centerHz` is absolute RF Hz, not baseband-relative.** Invisible on a
  direct-sampling HF receiver where `Frontend.frequency` is ~0; on a
  tuner-based front end, getting it wrong costs you the full LO frequency.
- **A mode command is only ACKed, never confirmed.** `M_FORCE:` reports drift,
  but nothing is sent when the preset matches what the session asked for — so
  a client can't wait for a state echo the way it can when tuning. That
  asymmetry with `BFREQ` cost me some time before I read the server logic.
- **Sessions are reattached by client address.** `BFREQ` may therefore never
  arrive on connect, and clients sharing a source address — behind one NAT or
  a reverse proxy — share a session and can change each other's tuning. Your
  own comment anticipates the `127.0.0.1` case; I've written it up as a
  deployment consideration rather than proposing any change to it.

Corrections very welcome, particularly anywhere I've inferred intent from
`radio.js` rather than from you. If any of it is wrong I'd rather it not be
documented at all than documented incorrectly.

73,
Stan / ON8ST
